### PR TITLE
Propagate "system" directives to chat models

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use the `.http` files to send requests, install the [REST Client](https://mar
 1. Send a prompt request:
 
    ```http
-   POST http://localhost:5111/prompt HTTP/1.1
+   POST http://localhost:5111/complete HTTP/1.1
    content-type: application/json
 
    {

--- a/src/DaprAI.Application/DaprClientExtensions.cs
+++ b/src/DaprAI.Application/DaprClientExtensions.cs
@@ -4,9 +4,9 @@ namespace DaprAI;
 
 internal static class DaprClientExtensions
 {
-    public static Task<PromptResponse> PromptAIAsync(this DaprClient daprClient, string component, PromptRequest request) =>
-        daprClient.InvokeBindingAsync<PromptRequest, PromptResponse>(component, "prompt", request);
+    public static Task<DaprCompletionResponse> CompleteTextAsync(this DaprClient daprClient, string component, DaprCompletionRequest request) =>
+        daprClient.InvokeBindingAsync<DaprCompletionRequest, DaprCompletionResponse>(component, Constants.Operations.CompleteText, request);
 
-    public static Task<PromptResponse> SummarizeAIAsync(this DaprClient daprClient, string component, PromptRequest request) =>
-        daprClient.InvokeBindingAsync<PromptRequest, PromptResponse>(component, "summarize", request);
+    public static Task<DaprCompletionResponse> SummarizeTextAsync(this DaprClient daprClient, string component, DaprCompletionRequest request) =>
+        daprClient.InvokeBindingAsync<DaprCompletionRequest, DaprCompletionResponse>(component, Constants.Operations.SummarizeText, request);
 }

--- a/src/DaprAI.Application/Program.cs
+++ b/src/DaprAI.Application/Program.cs
@@ -22,12 +22,12 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapPost(
-    "/prompt",
-    async ([FromQuery] string? component, [FromBody] PromptRequest request, [FromServices] DaprClient daprClient) =>
+    "/complete",
+    async ([FromQuery] string? component, [FromBody] DaprCompletionRequest request, [FromServices] DaprClient daprClient) =>
     {
         component ??= ChatGpt;
 
-        var response = await daprClient.PromptAIAsync(component, request);
+        var response = await daprClient.CompleteTextAsync(component, request);
 
         return response;
     })
@@ -36,11 +36,11 @@ app.MapPost(
 
 app.MapPost(
     "/summarize",
-    async ([FromQuery] string? component, [FromBody] PromptRequest request, [FromServices] DaprClient daprClient) =>
+    async ([FromQuery] string? component, [FromBody] DaprCompletionRequest request, [FromServices] DaprClient daprClient) =>
     {
         component ??= ChatGpt;
 
-        var response = await daprClient.SummarizeAIAsync(component, request);
+        var response = await daprClient.SummarizeTextAsync(component, request);
 
         return response;
     })

--- a/src/DaprAI.Application/api.http
+++ b/src/DaprAI.Application/api.http
@@ -1,4 +1,4 @@
-POST http://localhost:5111/prompt HTTP/1.1
+POST http://localhost:5111/complete HTTP/1.1
 content-type: application/json
 
 {

--- a/src/DaprAI.Application/components/azure-open-ai-davinci.yaml
+++ b/src/DaprAI.Application/components/azure-open-ai-davinci.yaml
@@ -16,5 +16,11 @@ spec:
       secretKeyRef:
         name: azure-open-ai-key
         key: azure-open-ai-key
+    - name: maxTokens
+      value: 64
+    - name: temperature
+      value: 0.9
+    - name: topP
+      value: 1.0
 auth:
   secretStore: secrets

--- a/src/DaprAI.Application/components/azure-open-ai-gpt.yaml
+++ b/src/DaprAI.Application/components/azure-open-ai-gpt.yaml
@@ -16,5 +16,11 @@ spec:
       secretKeyRef:
         name: azure-open-ai-key
         key: azure-open-ai-key
+    - name: maxTokens
+      value: 64
+    - name: temperature
+      value: 0.9
+    - name: topP
+      value: 1.0
 auth:
   secretStore: secrets

--- a/src/DaprAI.Application/components/open-ai-davinci-binding.yaml
+++ b/src/DaprAI.Application/components/open-ai-davinci-binding.yaml
@@ -14,5 +14,11 @@ spec:
         key: open-api-key
     - name: model
       value: text-davinci-003
+    - name: maxTokens
+      value: 64
+    - name: temperature
+      value: 0.9
+    - name: topP
+      value: 1.0
 auth:
   secretStore: secrets

--- a/src/DaprAI.Application/components/open-ai-gpt-binding.yaml
+++ b/src/DaprAI.Application/components/open-ai-gpt-binding.yaml
@@ -14,5 +14,11 @@ spec:
         key: open-api-key
     - name: model
       value: gpt-3.5-turbo
+    - name: maxTokens
+      value: 64
+    - name: temperature
+      value: 0.9
+    - name: topP
+      value: 1.0
 auth:
   secretStore: secrets

--- a/src/DaprAI.Common/Constants.cs
+++ b/src/DaprAI.Common/Constants.cs
@@ -1,0 +1,10 @@
+namespace DaprAI;
+
+public static class Constants
+{
+    public static class Operations
+    {
+        public const string CompleteText = "completeText";
+        public const string SummarizeText = "summarizeText";
+    }
+}

--- a/src/DaprAI.Common/DaprCompletionRequest.cs
+++ b/src/DaprAI.Common/DaprCompletionRequest.cs
@@ -8,6 +8,10 @@ public sealed record DaprCompletionRequest(
     [property: JsonPropertyName("prompt")]
     string Prompt)
 {
+    [JsonPropertyName("system")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? System { get; init; }
+
     public static DaprCompletionRequest FromBytes(ReadOnlySpan<byte> bytes)
     {
         var requestJson = Encoding.UTF8.GetString(bytes);

--- a/src/DaprAI.Common/DaprCompletionRequest.cs
+++ b/src/DaprAI.Common/DaprCompletionRequest.cs
@@ -4,14 +4,14 @@ using System.Text.Json.Serialization;
 
 namespace DaprAI;
 
-public sealed record PromptRequest(
+public sealed record DaprCompletionRequest(
     [property: JsonPropertyName("prompt")]
     string Prompt)
 {
-    public static PromptRequest FromBytes(ReadOnlySpan<byte> bytes)
+    public static DaprCompletionRequest FromBytes(ReadOnlySpan<byte> bytes)
     {
         var requestJson = Encoding.UTF8.GetString(bytes);
-        var request = JsonSerializer.Deserialize<PromptRequest>(requestJson);
+        var request = JsonSerializer.Deserialize<DaprCompletionRequest>(requestJson);
 
         if (request is null)
         {

--- a/src/DaprAI.Common/DaprCompletionResponse.cs
+++ b/src/DaprAI.Common/DaprCompletionResponse.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace DaprAI;
 
-public sealed record PromptResponse(
+public sealed record DaprCompletionResponse(
     [property: JsonPropertyName("response")]
     string Response)
 {

--- a/src/DaprAI.Components/Bindings/AzureAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/AzureAIBindings.cs
@@ -25,14 +25,14 @@ internal sealed class AzureAIBindings : IOutputBinding
     {
         return request.Operation switch
         {
-            "summarize" => this.SummarizeAsync(request, cancellationToken),
+            Constants.Operations.SummarizeText => this.SummarizeAsync(request, cancellationToken),
             _ => throw new NotImplementedException(),
         };
     }
 
     public Task<string[]> ListOperationsAsync(CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(new[] { "summarize" });
+        return Task.FromResult(new[] { Constants.Operations.SummarizeText });
     }
 
     #endregion
@@ -42,7 +42,7 @@ internal sealed class AzureAIBindings : IOutputBinding
         var credentials = new AzureKeyCredential(this.azureAIKey!);
         var client = new TextAnalyticsClient(new Uri(this.azureAIEndpoint!), credentials);
 
-        var summarizeRequest = PromptRequest.FromBytes(request.Data.Span);
+        var summarizeRequest = DaprCompletionRequest.FromBytes(request.Data.Span);
 
         var operation = await client.StartAnalyzeActionsAsync(
             new[]
@@ -82,6 +82,6 @@ internal sealed class AzureAIBindings : IOutputBinding
             }
         }
 
-        return new OutputBindingInvokeResponse { Data = new PromptResponse(String.Join(' ', sentences)).ToBytes() };
+        return new OutputBindingInvokeResponse { Data = new DaprCompletionResponse(String.Join(' ', sentences)).ToBytes() };
     }
 }

--- a/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
@@ -26,7 +26,7 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
         headers.Add("api-key", this.Key);
     }
 
-    protected override async Task<PromptResponse> OnPromptAsync(PromptRequest promptRequest, CancellationToken cancellationToken)
+    protected override async Task<DaprCompletionResponse> OnPromptAsync(DaprCompletionRequest promptRequest, CancellationToken cancellationToken)
     {
         var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
             new CompletionsRequest(promptRequest.Prompt),
@@ -40,6 +40,6 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
             throw new InvalidOperationException("No text was returned.");
         }
 
-        return new PromptResponse(text);
+        return new DaprCompletionResponse(text);
     }
 }

--- a/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
@@ -1,13 +1,23 @@
 using System.Net.Http.Headers;
+using System.Text.Json.Serialization;
 using Dapr.PluggableComponents.Components;
 
 namespace DaprAI.Bindings;
 
 internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
 {
-    private static readonly HttpClient HttpClient = new();
+    private static readonly ISet<string> ChatCompletionModels = new HashSet<string>
+    {
+        "gpt-35-turbo"
+    };
 
     private string? azureOpenAIDeployment;
+    private Lazy<Task<bool>> isChatCompletion;
+
+    public AzureOpenAIBindings()
+    {
+        this.isChatCompletion = new Lazy<Task<bool>>(this.IsDeploymentChatCompletionModel);
+    }
 
     protected override async Task OnInitAsync(MetadataRequest request, CancellationToken cancellationToken = default)
     {
@@ -28,8 +38,28 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
 
     protected override async Task<DaprCompletionResponse> OnPromptAsync(DaprCompletionRequest promptRequest, CancellationToken cancellationToken)
     {
+        var isChatCompletion = await this.isChatCompletion.Value;
+
+        CompletionsRequest azureRequest;
+
+        if (isChatCompletion)
+        {
+            string system = promptRequest.System != null ? $"<|im_start|>system\n{promptRequest.System}\n<|im_end|>\n" : String.Empty;
+            string user = $"<|im_start|>user\n{promptRequest.Prompt}\n<|im_end|>\n";
+            string prompt = $"{system}{user}<|im_start|>assistant";
+
+            azureRequest = new CompletionsRequest(prompt)
+            {
+                Stop = new[] { "<|im_end|>" },
+            };
+        }
+        else
+        {
+            azureRequest = new CompletionsRequest(promptRequest.Prompt);
+        }
+
         var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
-            new CompletionsRequest(promptRequest.Prompt),
+            azureRequest,
             new Uri($"{this.Endpoint}/openai/deployments/{this.azureOpenAIDeployment}/completions?api-version=2022-12-01"),
             cancellationToken);
 
@@ -41,5 +71,46 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
         }
 
         return new DaprCompletionResponse(text);
+    }
+
+    private async Task<bool> IsDeploymentChatCompletionModel()
+    {
+        var response = await this.HttpClient.GetFromJsonAsync<GetDeploymentResponse>(
+            new Uri($"{this.Endpoint}/openai/deployments/{this.azureOpenAIDeployment}?api-version=2022-12-01"));
+
+        return response?.Model != null && ChatCompletionModels.Contains(response.Model);
+    }
+
+    private sealed record DeploymentScaleSettings
+    {
+        [JsonPropertyName("scale_type")]
+        public string? ScaleType { get; init; }
+    }
+
+    private sealed record GetDeploymentResponse
+    {
+        [JsonPropertyName("scale_settings")]
+        public DeploymentScaleSettings? ScaleSettings { get; init; }
+
+        [JsonPropertyName("model")]
+        public string? Model { get; init; }
+
+        [JsonPropertyName("owner")]
+        public string? Owner { get; init; }
+
+        [JsonPropertyName("id")]
+        public string? Id { get; init; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; init; }
+
+        [JsonPropertyName("created_at")]
+        public int? CreatedAt { get; init; }
+
+        [JsonPropertyName("updated_at")]
+        public int? UpdatedAt { get; init; }
+
+        [JsonPropertyName("object")]
+        public string? Object { get; init; }
     }
 }

--- a/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/AzureOpenAIBindings.cs
@@ -46,7 +46,7 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
         {
             string system = promptRequest.System != null ? $"<|im_start|>system\n{promptRequest.System}\n<|im_end|>\n" : String.Empty;
             string user = $"<|im_start|>user\n{promptRequest.Prompt}\n<|im_end|>\n";
-            string prompt = $"{system}{user}<|im_start|>assistant";
+            string prompt = $"{system}{user}<|im_start|>assistant\n";
 
             azureRequest = new CompletionsRequest(prompt)
             {
@@ -57,6 +57,13 @@ internal sealed class AzureOpenAIBindings : OpenAIBindingsBase
         {
             azureRequest = new CompletionsRequest(promptRequest.Prompt);
         }
+
+        azureRequest = azureRequest with
+            {
+                MaxTokens = this.MaxTokens,
+                Temperature = this.Temperature,
+                TopP = this.TopP
+            };
 
         var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
             azureRequest,

--- a/src/DaprAI.Components/Bindings/OpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindings.cs
@@ -50,11 +50,9 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
                         : new[] { userMessage })
                 {
                     Model = this.model,
-                    Temperature = 0.9m,
-                    MaxTokens = 64,
-                    TopP = 1.0m,
-                    FrequencyPenalty = 0.0m,
-                    PresencePenalty = 0.0m
+                    Temperature = this.Temperature,
+                    MaxTokens = this.MaxTokens,
+                    TopP = this.TopP,
                 },
                 new Uri($"{this.Endpoint}/v1/chat/completions"),
                 cancellationToken);
@@ -74,11 +72,9 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
                 new CompletionsRequest(promptRequest.Prompt)
                 {
                     Model = this.model,
-                    Temperature = 0.9m,
-                    MaxTokens = 64,
-                    TopP = 1.0m,
-                    FrequencyPenalty = 0.0m,
-                    PresencePenalty = 0.0m
+                    Temperature = this.Temperature,
+                    MaxTokens = this.MaxTokens,
+                    TopP = this.TopP
                 },
                 new Uri($"{this.Endpoint}/v1/completions"),
                 cancellationToken);

--- a/src/DaprAI.Components/Bindings/OpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindings.cs
@@ -37,7 +37,7 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
         headers.Authorization = new AuthenticationHeaderValue("Bearer", this.Key);
     }
 
-    protected override async Task<PromptResponse> OnPromptAsync(PromptRequest promptRequest, CancellationToken cancellationToken)
+    protected override async Task<DaprCompletionResponse> OnPromptAsync(DaprCompletionRequest promptRequest, CancellationToken cancellationToken)
     {
         if (this.IsChatCompletion())
         {
@@ -61,7 +61,7 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
                 throw new InvalidOperationException("No chat content was returned.");
             }
 
-            return new PromptResponse(content);
+            return new DaprCompletionResponse(content);
         }
         else
         {
@@ -85,7 +85,7 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
                 throw new InvalidOperationException("No text was returned.");
             }
 
-            return new PromptResponse(text);
+            return new DaprCompletionResponse(text);
         }
     }
 

--- a/src/DaprAI.Components/Bindings/OpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindings.cs
@@ -41,8 +41,13 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
     {
         if (this.IsChatCompletion())
         {
+            var userMessage = new ChatCompletionMessage("user", promptRequest.Prompt);
+
             var response = await this.SendRequestAsync<ChatCompletionsRequest, ChatCompletionsResponse>(
-                new ChatCompletionsRequest(new[] { new ChatCompletionMessage("user", promptRequest.Prompt) })
+                new ChatCompletionsRequest(
+                    !String.IsNullOrEmpty(promptRequest.System)
+                        ? new[] { new ChatCompletionMessage("system", promptRequest.System), userMessage }
+                        : new[] { userMessage })
                 {
                     Model = this.model,
                     Temperature = 0.9m,

--- a/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
@@ -32,7 +32,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
         }
     }
 
-    private readonly HttpClient httpClient;
+    protected HttpClient HttpClient { get; private set; }
 
     private string? azureOpenAIEndpoint;
     private string? azureOpenAIKey;
@@ -43,7 +43,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
     protected OpenAIBindingsBase()
     {
-        this.httpClient = new HttpClient(new HeadersProcessingHandler(this.OnAttachHeaders));
+        this.HttpClient = new HttpClient(new HeadersProcessingHandler(this.OnAttachHeaders));
     }
 
     #region IOutputBinding Members
@@ -100,7 +100,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
                 "application/json")
         };
 
-        var response = await httpClient.SendAsync(message, cancellationToken);
+        var response = await this.HttpClient.SendAsync(message, cancellationToken);
 
         response.EnsureSuccessStatusCode();
 
@@ -148,6 +148,10 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
         [JsonPropertyName("presence_penalty")]
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public decimal? PresencePenalty { get; init; }
+
+        [JsonPropertyName("stop")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? Stop { get; init; }
     }
 
     protected sealed record CompletionsRequest(

--- a/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
@@ -57,14 +57,14 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
     {
         return request.Operation switch
         {
-            "prompt" => this.PromptAsync(request, cancellationToken),
+            Constants.Operations.CompleteText => this.PromptAsync(request, cancellationToken),
             _ => throw new NotImplementedException(),
         };
     }
 
     public Task<string[]> ListOperationsAsync(CancellationToken cancellationToken = default)
     {
-        return Task.FromResult(new[] { "prompt" });
+        return Task.FromResult(new[] { Constants.Operations.CompleteText });
     }
 
     #endregion
@@ -84,7 +84,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
         return Task.CompletedTask;
     }
 
-    protected abstract Task<PromptResponse> OnPromptAsync(PromptRequest promptRequest, CancellationToken cancellationToken);
+    protected abstract Task<DaprCompletionResponse> OnPromptAsync(DaprCompletionRequest promptRequest, CancellationToken cancellationToken);
     
     protected virtual void OnAttachHeaders(HttpRequestHeaders headers)
     {
@@ -116,7 +116,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
     private async Task<OutputBindingInvokeResponse> PromptAsync(OutputBindingInvokeRequest request, CancellationToken cancellationToken)
     {
-        var promptRequest = PromptRequest.FromBytes(request.Data.Span);
+        var promptRequest = DaprCompletionRequest.FromBytes(request.Data.Span);
 
         var promptResponse = await this.OnPromptAsync(promptRequest, cancellationToken);
 

--- a/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
@@ -37,14 +37,20 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
     private string? azureOpenAIEndpoint;
     private string? azureOpenAIKey;
 
-    protected string? Endpoint => this.azureOpenAIEndpoint;
-
-    protected string? Key => this.azureOpenAIKey;
-
     protected OpenAIBindingsBase()
     {
         this.HttpClient = new HttpClient(new HeadersProcessingHandler(this.OnAttachHeaders));
     }
+
+    protected string? Endpoint => this.azureOpenAIEndpoint;
+
+    protected string? Key => this.azureOpenAIKey;
+
+    protected int? MaxTokens { get; private set; }
+
+    protected decimal? Temperature { get; private set; }
+
+    protected decimal? TopP { get; private set; }
 
     #region IOutputBinding Members
 
@@ -79,6 +85,21 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
         if (!request.Properties.TryGetValue("key", out this.azureOpenAIKey))
         {
             throw new InvalidOperationException("Missing required metadata property 'key'.");
+        }
+
+        if (request.Properties.TryGetValue("maxTokens", out var maxTokens))
+        {
+            this.MaxTokens = Int32.Parse(maxTokens);
+        }
+
+        if (request.Properties.TryGetValue("temperature", out var temperature))
+        {
+            this.Temperature = Decimal.Parse(temperature);
+        }
+
+        if (request.Properties.TryGetValue("topP", out var topP))
+        {
+            this.TopP = Decimal.Parse(topP);
         }
 
         return Task.CompletedTask;


### PR DESCRIPTION
When using chat-based language models, allows callers to set the "system" directive (e.g. often used to tell the AI *how* to respond to the prompt, such as always responding in rhyme).  Ignored for models which do not support such directives.  Notable because of the difference in how services (e.g. Open AI vs. Azure Open AI) specify such directives (i.e. separate vs. inline).