### PR TITLE
Add GPT-4 support to Azure Open AI binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ The `docker-compose.yaml` in the repo root will deploy the application, Dapr sid
    >  - Open AI's Chat GPT (e.g. `?component=open-ai-gpt`)
    >  - Open AI's Davinci (e.g. `?component=open-ai-davinci`)
    >  - Azure Open AI Davinci (e.g. `?component=azure-open-ai-davinci`)
-   >  - Azure Open AI Chat GPT (e.g. `?component=azure-open-ai-gpt`)
+   >  - Azure Open AI Chat GPT 3.5 (e.g. `?component=azure-open-ai-gpt-3`)
+   >  - Azure Open AI Chat GPT 4 (e.g. `?component=azure-open-ai-gpt-4`)
    >  - Azure AI (e.g. `?component=azure-ai`)
    >
    > Not all operations (i.e. prompt or summarize) are supported by all bindings.

--- a/src/DaprAI.Application/components/azure-open-ai-gpt-3.yaml
+++ b/src/DaprAI.Application/components/azure-open-ai-gpt-3.yaml
@@ -1,0 +1,28 @@
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: azure-open-ai-gpt-3
+spec:
+  type: bindings.azure-open-ai
+  version: v1
+  metadata:
+    - name: deployment
+      value: gpt-35
+    - name: endpoint
+      secretKeyRef:
+        name: azure-open-ai-endpoint
+        key: azure-open-ai-endpoint
+    - name: key
+      secretKeyRef:
+        name: azure-open-ai-key
+        key: azure-open-ai-key
+    - name: maxTokens
+      value: 64
+    - name: summarizationInstructions
+      value: "You are an AI assistant that helps 2nd-graders summarize text. Respond to each user's message with a summarization of that message's text."
+    - name: temperature
+      value: 0.9
+    - name: topP
+      value: 1.0
+auth:
+  secretStore: secrets

--- a/src/DaprAI.Application/components/azure-open-ai-gpt-4.yaml
+++ b/src/DaprAI.Application/components/azure-open-ai-gpt-4.yaml
@@ -1,13 +1,13 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: azure-open-ai-gpt
+  name: azure-open-ai-gpt-4
 spec:
   type: bindings.azure-open-ai
   version: v1
   metadata:
     - name: deployment
-      value: gpt-35
+      value: gpt-4
     - name: endpoint
       secretKeyRef:
         name: azure-open-ai-endpoint

--- a/src/DaprAI.Components/Bindings/OpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindings.cs
@@ -1,8 +1,5 @@
-using System.Globalization;
 using System.Net.Http.Headers;
-using System.Text.Json.Serialization;
 using Dapr.PluggableComponents.Components;
-using DaprAI.Utilities;
 
 namespace DaprAI.Bindings;
 
@@ -33,10 +30,10 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
 
     private string? model;
 
-    protected override Uri GetCompletionsUrl(Uri baseEndpoint, bool chatCompletionsUrl)
+    protected override Uri GetCompletionsUrl(bool chatCompletionsUrl)
     {
         return new Uri(
-            baseEndpoint,
+            this.Endpoint!,
             chatCompletionsUrl ? "v1/chat/completions" : "v1/completions");
     }
 

--- a/src/DaprAI.Components/Bindings/OpenAIBindings.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindings.cs
@@ -33,131 +33,38 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
 
     private string? model;
 
+    protected override Uri GetCompletionsUrl(Uri baseEndpoint, bool chatCompletionsUrl)
+    {
+        return new Uri(
+            baseEndpoint,
+            chatCompletionsUrl ? "v1/chat/completions" : "v1/completions");
+    }
+
+    protected override Task<bool> IsChatCompletionModelAsync(CancellationToken cancellationToken)
+    {
+        if (this.model == null)
+        {
+            throw new InvalidOperationException("Missing required metadata property 'model'.");
+        }
+        else if (ChatCompletionModels.Contains(this.model))
+        {
+            return Task.FromResult(true);
+        }
+        else if (CompletionModels.Contains(this.model))
+        {
+            return Task.FromResult(false);
+        }
+        else
+        {
+            throw new InvalidOperationException($"Unrecognized model '{this.model}'.");
+        }
+    }
+
     protected override void OnAttachHeaders(HttpRequestHeaders headers)
     {
         base.OnAttachHeaders(headers);
 
         headers.Authorization = new AuthenticationHeaderValue("Bearer", this.Key);
-    }
-
-    private sealed record ChatHistoryItem(
-        [property: JsonPropertyName("role")]
-        string Role,
-
-        [property: JsonPropertyName("message")]
-        string Message);
-
-    private sealed record ChatHistory(
-        [property: JsonPropertyName("items")]
-        ChatHistoryItem[] Items);
-
-    protected override async Task<DaprCompletionResponse> OnCompleteAsync(DaprCompletionRequest completionRequest, CancellationToken cancellationToken)
-    {
-        if (this.IsChatCompletion())
-        {
-            var messages = new List<ChatCompletionMessage>(completionRequest.History?.Items.Select(item => new ChatCompletionMessage(item.Role, item.Message)) ?? Enumerable.Empty<ChatCompletionMessage>());
-
-            messages.Add(new ChatCompletionMessage("user", completionRequest.UserPrompt));
-
-            var response = await this.SendRequestAsync<ChatCompletionsRequest, ChatCompletionsResponse>(
-                new ChatCompletionsRequest(messages.ToArray())
-                {
-                    Model = this.model,
-                    Temperature = this.Temperature,
-                    MaxTokens = this.MaxTokens,
-                    TopP = this.TopP,
-                },
-                new Uri($"{this.Endpoint}/v1/chat/completions"),
-                cancellationToken);
-
-            var content = response.Choices.FirstOrDefault()?.Message?.Content;
-
-            if (content == null)
-            {
-                throw new InvalidOperationException("No chat content was returned.");
-            }
-
-            return new DaprCompletionResponse(content);
-        }
-        else
-        {
-            var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
-                new CompletionsRequest(completionRequest.UserPrompt)
-                {
-                    Model = this.model,
-                    Temperature = this.Temperature,
-                    MaxTokens = this.MaxTokens,
-                    TopP = this.TopP
-                },
-                new Uri($"{this.Endpoint}/v1/completions"),
-                cancellationToken);
-
-            var text = response.Choices.FirstOrDefault()?.Text;
-
-            if (text == null)
-            {
-                throw new InvalidOperationException("No text was returned.");
-            }
-
-            return new DaprCompletionResponse(text);
-        }
-    }
-
-    protected override async Task<DaprSummarizationResponse> OnSummarizeAsync(DaprSummarizationRequest summarizationRequest, CancellationToken cancellationToken)
-    {
-        string documentText = await SummarizationUtilities.GetDocumentText(summarizationRequest, cancellationToken);
-
-        string summarizationInstructions = String.Format(
-            CultureInfo.CurrentCulture,
-            this.SummarizationInstructions ?? throw new InvalidOperationException("Missing required metadata property 'summarizationInstructions'."),
-            documentText);
-
-        string? summary;
-
-        if (this.IsChatCompletion())
-        {
-            var response = await this.SendRequestAsync<ChatCompletionsRequest, ChatCompletionsResponse>(
-                new ChatCompletionsRequest(
-                    new[]
-                    {
-                        new ChatCompletionMessage("system", summarizationInstructions),
-                        new ChatCompletionMessage("user", documentText)
-                    })
-                {
-                    Model = this.model,
-                    Temperature = this.Temperature,
-                    MaxTokens = this.MaxTokens,
-                    TopP = this.TopP,
-                },
-                new Uri($"{this.Endpoint}/v1/chat/completions"),
-                cancellationToken);
-
-            summary = response.Choices.FirstOrDefault()?.Message?.Content;
-        }
-        else
-        {
-            string prompt = $"Summarize the following text: {documentText}";
-
-            var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
-                new CompletionsRequest(summarizationInstructions)
-                {
-                    Model = this.model,
-                    Temperature = this.Temperature,
-                    MaxTokens = this.MaxTokens,
-                    TopP = this.TopP
-                },
-                new Uri($"{this.Endpoint}/v1/completions"),
-                cancellationToken);
-
-            summary = response.Choices.FirstOrDefault()?.Text;
-        }
-
-        if (summary == null)
-        {
-            throw new InvalidOperationException("No summary was returned.");
-        }
-
-        return new DaprSummarizationResponse(summary);
     }
 
     protected override async Task OnInitAsync(MetadataRequest request, CancellationToken cancellationToken)
@@ -170,23 +77,13 @@ internal sealed class OpenAIBindings : OpenAIBindingsBase
         }
     }
 
-    private bool IsChatCompletion()
+    protected override ChatCompletionsRequest UpdateChatCompletionsRequest(ChatCompletionsRequest request)
     {
-        if (this.model == null)
-        {
-            throw new InvalidOperationException("Missing required metadata property 'model'.");
-        }
-        else if (ChatCompletionModels.Contains(this.model))
-        {
-            return true;
-        }
-        else if (CompletionModels.Contains(this.model))
-        {
-            return false;
-        }
-        else
-        {
-            throw new InvalidOperationException($"Unrecognized model '{this.model}'.");
-        }
+        return request with { Model = this.model };
+    }
+
+    protected override CompletionsRequest UpdateCompletionsRequest(CompletionsRequest request)
+    {
+        return request with { Model = this.model };
     }
 }

--- a/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
+++ b/src/DaprAI.Components/Bindings/OpenAIBindingsBase.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Dapr.Client;
 using Dapr.PluggableComponents.Components;
 using Dapr.PluggableComponents.Components.Bindings;
 using DaprAI.Utilities;
@@ -84,7 +83,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
     {
     }
 
-    protected abstract Uri GetCompletionsUrl(Uri baseEndpoint, bool chatCompletionsUrl);
+    protected abstract Uri GetCompletionsUrl(bool chatCompletionsUrl);
 
     protected virtual Task<bool> IsChatCompletionModelAsync(CancellationToken cancellationToken)
     {
@@ -167,7 +166,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
             var response = await this.SendRequestAsync<ChatCompletionsRequest, ChatCompletionsResponse>(
                 request,
-                this.GetCompletionsUrl(this.Endpoint!, true),
+                this.GetCompletionsUrl(true),
                 cancellationToken);
 
             var content = response.Choices.FirstOrDefault()?.Message?.Content;
@@ -191,7 +190,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
             var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
                 request,
-                this.GetCompletionsUrl(this.Endpoint!, false),
+                this.GetCompletionsUrl(false),
                 cancellationToken);
 
             var text = response.Choices.FirstOrDefault()?.Text;
@@ -233,7 +232,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
             var response = await this.SendRequestAsync<ChatCompletionsRequest, ChatCompletionsResponse>(
                 request,
-                this.GetCompletionsUrl(this.Endpoint!, true),
+                this.GetCompletionsUrl(true),
                 cancellationToken);
 
             summary = response.Choices.FirstOrDefault()?.Message?.Content;
@@ -250,7 +249,7 @@ internal abstract class OpenAIBindingsBase : IOutputBinding
 
             var response = await this.SendRequestAsync<CompletionsRequest, CompletionsResponse>(
                 request,
-                this.GetCompletionsUrl(this.Endpoint!, false),
+                this.GetCompletionsUrl(false),
                 cancellationToken);
 
             summary = response.Choices.FirstOrDefault()?.Text;


### PR DESCRIPTION
Azure's support for GPT-4 requires the newer "chat completion" API (vs. the existing "ChatML" API).  (The other models can use the new API, but GPT-4 is the only that *requires* it.) The new API is much closer to Open API's API, which allows for a lot of consolidation and sharing of binding logic.